### PR TITLE
Allow options to be required

### DIFF
--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -18,8 +18,8 @@ module Settings
     root_collection.collection?(key)
   end
 
-  def self.store_at(path, key, value)
-    root_collection.store_at(path, key, value)
+  def self.store_at(path, key, value, **options)
+    root_collection.store_at(path, key, value, options)
   end
 
   def self.reset

--- a/lib/settings/collection.rb
+++ b/lib/settings/collection.rb
@@ -12,21 +12,21 @@ module Settings
       @collections = Hash.new
     end
 
-    def store(key, value)
+    def store(key, value, **options)
       key = key.to_s
       if settings.include?(key)
         raise ExistingSetting, "Existing setting for #{key}"
       else
-        settings[key] = Setting.new(key: key, value: value)
+        settings[key] = Setting.new(key: key, value: value, **options)
       end
     end
 
-    def store_at(path, key, value)
+    def store_at(path, key, value, **options)
       if path.empty?
-        store(key, value)
+        store(key, value, options)
       else
         collection_name, *rest = path
-        collection(collection_name).store_at(rest, key, value)
+        collection(collection_name).store_at(rest, key, value, options)
       end
     end
 

--- a/lib/settings/configuration.rb
+++ b/lib/settings/configuration.rb
@@ -10,9 +10,9 @@ module Settings
     module ClassMethods
       include Utils
 
-      def setting(key, value)
+      def setting(key, value, **options)
         path = collection_path(self)
-        Settings.store_at(path, key, value)
+        Settings.store_at(path, key, value, options)
       end
     end
   end

--- a/lib/settings/setting.rb
+++ b/lib/settings/setting.rb
@@ -1,10 +1,32 @@
 module Settings
   class Setting
-    attr_reader :value
-
-    def initialize(key:, value:)
+    def initialize(key:, value:, **options)
       @key = key
       @value = value
+      @options = options
     end
+
+    def value
+      if required && !value_present?
+        raise StandardError.new("Value is required, but was not present")
+      else
+        @value
+      end
+    end
+
+    private
+
+    attr_reader :options
+
+    def required
+      options[:required]
+    end
+
+    # For now nil is all we will check for. We can imagine that we might want to
+    # prevent empty collections or strings as well
+    def value_present?
+      !@value.nil?
+    end
+
   end
 end

--- a/spec/settings/setting_spec.rb
+++ b/spec/settings/setting_spec.rb
@@ -6,4 +6,18 @@ RSpec.describe Settings::Setting do
       expect(setting.value).to eq "abc123"
     end
   end
+
+  describe "required option" do
+    it "will raise error if not found" do
+      setting = Settings::Setting.new(key: "foo", value: nil, required: true)
+
+      expect { setting.value }.to raise_error StandardError
+    end
+
+    it "will return a thing and not error if not required" do
+      setting = Settings::Setting.new(key: "foo", value: nil, required: false)
+
+      expect(setting.value).to eq nil
+    end
+  end
 end

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -29,6 +29,18 @@ RSpec.describe Settings do
     end
   end
 
+  describe "accessing a required setting that is nil" do
+    it "raises an error" do
+      class RequiredTest
+        include Settings::Configuration
+
+        setting :api_key, nil, required: true
+      end
+
+      expect { Settings.required_test.api_key }.to raise_error StandardError
+    end
+  end
+
   describe ".register_collection" do
     it "registers a new collection" do
       Settings.register_collection("foo")


### PR DESCRIPTION
If an option is required, and the value is `nil`, an error is raised.
`required` is false by default.

Co-authored-by: Brian Tenggren <btenggren20@gmail.com>